### PR TITLE
Map between LDAP and Murmur group membership

### DIFF
--- a/root/config/LDAPauth.ini
+++ b/root/config/LDAPauth.ini
@@ -39,6 +39,12 @@ provide_users = True
 ; Uncomment to use StartTLS without cert check
 ; use_start_tls = True
 
+; Murmur group to LDAP group mapping
+[group_map]
+; Format: murmur-group = cn=group,ou=ldap,dc=example,dc=org
+; Grants users the given Murmur group if they are in the given LDAP group DN
+; admin = cn=admin,ou=groups,dc=example,dc=org
+
 ;Murmur configuration
 [murmur]
 ;List of virtual server IDs, empty = all


### PR DESCRIPTION
This PR allows LDAP users to be granted Murmur groups (eg, `admin`) based on LDAP groups they are a part of. To map between an LDAP group and a Murmur group, the following configuration may be used:

```ini
[group_map]
murmur-group = cn=group,ou=groups,dc=example,dc=org
```

For backwards compatibility purposes, this PR has no effect; any configurations missing the `group_map` section (or ones with nonexistent Murmur/LDAP groups listed) will simply perform authentication as normal.